### PR TITLE
Support manual cache eviction

### DIFF
--- a/aws_secretsmanager_agent/src/cache_manager.rs
+++ b/aws_secretsmanager_agent/src/cache_manager.rs
@@ -91,8 +91,17 @@ impl CacheManager {
             }
         }
     }
-}
 
+    pub async fn evict_entry(&self, secret_id: &str) -> Result<(), HttpError> {
+        match self.0.invalidate(secret_id) {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                error!("Failed to evict secret {}: {:?}", secret_id, e);
+                Err(HttpError(500, err_response("EvictionError", "Failed to evict secret")))
+            }
+        }
+    }
+}
 /// Private helper to format in internal service error response.
 #[doc(hidden)]
 fn int_err() -> HttpError {

--- a/aws_secretsmanager_agent/src/config.rs
+++ b/aws_secretsmanager_agent/src/config.rs
@@ -35,6 +35,7 @@ struct ConfigFile {
     path_prefix: String,
     max_conn: String,
     region: Option<String>,
+    allow_eviction: String,
 }
 
 /// The log levels supported by the daemon.
@@ -93,6 +94,8 @@ pub struct Config {
 
     /// The AWS Region that will be used to send the Secrets Manager request to.
     region: Option<String>,
+
+    allow_eviction: bool,
 }
 
 /// The default configuration options.
@@ -134,7 +137,8 @@ impl Config {
             )?
             .set_default("path_prefix", DEFAULT_PATH_PREFIX)?
             .set_default("max_conn", DEFAULT_MAX_CONNECTIONS)?
-            .set_default("region", DEFAULT_REGION)?;
+            .set_default("region", DEFAULT_REGION)?
+            .set_default("allow_eviction", "false")?;
 
         // Merge the config overrides onto the default configurations, if provided.
         config = match file_path {
@@ -228,6 +232,10 @@ impl Config {
         self.region.as_ref()
     }
 
+    pub fn allow_eviction(&self) -> bool {
+        self.allow_eviction
+    }
+
     /// Private helper that fills in the Config instance from the specified
     /// config overrides (or defaults).
     ///
@@ -275,6 +283,7 @@ impl Config {
                 None,
             )?,
             region: config_file.region,
+            allow_eviction: parse_bool(&config_file.allow_eviction, "Invalid allow_eviction value")?,
         };
 
         // Additional validations.
@@ -289,6 +298,14 @@ impl Config {
         }
 
         Ok(config)
+    }
+}
+
+fn parse_bool(value: &str, error_msg: &str) -> Result<bool, Box<dyn std::error::Error>> {
+    match value.to_lowercase().as_str() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => Err(error_msg.into()),
     }
 }
 
@@ -357,6 +374,7 @@ mod tests {
             path_prefix: String::from(DEFAULT_PATH_PREFIX),
             max_conn: String::from(DEFAULT_MAX_CONNECTIONS),
             region: None,
+            allow_eviction: String::from("false"),
         }
     }
 
@@ -382,6 +400,7 @@ mod tests {
         assert_eq!(config.clone().path_prefix(), DEFAULT_PATH_PREFIX);
         assert_eq!(config.clone().max_conn(), 800);
         assert_eq!(config.clone().region(), None);
+        assert_eq!(config.allow_eviction(), false);
     }
 
     /// Tests the config overrides are applied correctly from the provided config file.
@@ -406,6 +425,7 @@ mod tests {
         assert_eq!(config.clone().path_prefix(), "/other");
         assert_eq!(config.clone().max_conn(), 10);
         assert_eq!(config.clone().region(), Some(&"us-west-2".to_string()));
+        assert_eq!(config.allow_eviction(), true);
     }
 
     /// Tests that an Err is returned when an invalid value is provided in one of the configurations.
@@ -596,5 +616,26 @@ mod tests {
             "tests/resources/configs/config_file_with_invalid_contents.toml",
         ))
         .unwrap();
+    }
+
+    #[test]
+    fn test_validate_allow_eviction() {
+        let valid_values = vec!["true", "false", "True", "False", "TRUE", "FALSE"];
+        for value in valid_values {
+            let config = ConfigFile {
+                allow_eviction: value.to_string(),
+                ..get_default_config_file()
+            };
+            assert!(Config::build(config).is_ok());
+        }
+
+        let invalid_values = vec!["yes", "no", "1", "0", "invalid"];
+        for value in invalid_values {
+            let config = ConfigFile {
+                allow_eviction: value.to_string(),
+                ..get_default_config_file()
+            };
+            assert!(Config::build(config).is_err());
+        }
     }
 }

--- a/aws_secretsmanager_agent/src/server.rs
+++ b/aws_secretsmanager_agent/src/server.rs
@@ -25,18 +25,19 @@ pub struct Server {
     ssrf_headers: Arc<Vec<String>>,
     path_prefix: Arc<String>,
     max_conn: usize,
+    allow_eviction: bool,
 }
 
 /// Handle incoming HTTP requests.
 ///
-/// Implements the HTTP handler. Each incomming request is handled in its own
+/// Implements the HTTP handler. Each incoming request is handled in its own
 /// thread.
 impl Server {
     /// Create a server instance.
     ///
     /// # Arguments
     ///
-    /// * `listener` - The TcpListener to use to accept incomming requests.
+    /// * `listener` - The TcpListener to use to accept incoming requests.
     /// * `cfg` - The config object to use for options such header names.
     ///
     /// # Returns
@@ -54,6 +55,7 @@ impl Server {
             ssrf_headers: Arc::new(cfg.ssrf_headers()),
             path_prefix: Arc::new(cfg.path_prefix()),
             max_conn: cfg.max_conn(),
+            allow_eviction: cfg.allow_eviction(),
         })
     }
 
@@ -87,11 +89,11 @@ impl Server {
         Ok(())
     }
 
-    /// Private helper to process the incomming request body and format a response.
+    /// Private helper to process the incoming request body and format a response.
     ///
     /// # Arguments
     ///
-    /// * `req` - The incomming HTTP request.
+    /// * `req` - The incoming HTTP request.
     /// * `count` - The number of concurrent requets being handled.
     ///
     /// # Returns
@@ -118,11 +120,11 @@ impl Server {
         }
     }
 
-    /// Parse an incomming request and provide the response data.
+    /// Parse an incoming request and provide the response data.
     ///
     /// # Arguments
     ///
-    /// * `req` - The incomming HTTP request.
+    /// * `req` - The incoming HTTP request.
     /// * `count` - The number of concurrent requets being handled.
     ///
     /// # Returns
@@ -135,15 +137,13 @@ impl Server {
         req: &Request<IncomingBody>,
         count: usize,
     ) -> Result<String, HttpError> {
-        self.validate_max_conn(req, count)?; // Verify connection limits are not exceeded
-        self.validate_token(req)?; // Check for a valid SSRF token
-        self.validate_method(req)?; // Allow only GET requests
+        self.validate_max_conn(req, count)?;
+        self.validate_token(req)?;
+        self.validate_method(req)?;
 
-        match req.uri().path() {
-            "/ping" => Ok("healthy".into()), // Standard health check
-
-            // Lambda extension style query
-            "/secretsmanager/get" => {
+        match (req.method(), req.uri().path()) {
+            (&Method::GET, "/ping") => Ok("healthy".into()),  // Standard health check
+            (&Method::GET, "/secretsmanager/get") => { // Lambda extension style query
                 let qry = GSVQuery::try_from_query(&req.uri().to_string())?;
                 Ok(self
                     .cache_mgr
@@ -154,9 +154,8 @@ impl Server {
                     )
                     .await?)
             }
-
             // Path style request
-            path if path.starts_with(self.path_prefix.as_str()) => {
+            (&Method::GET, path) if path.starts_with(self.path_prefix.as_str()) => {
                 let qry = GSVQuery::try_from_path_query(&req.uri().to_string(), &self.path_prefix)?;
                 Ok(self
                     .cache_mgr
@@ -167,17 +166,31 @@ impl Server {
                     )
                     .await?)
             }
+            (&Method::POST, "/evict") => {
+                if !self.allow_eviction {
+                    return Err(HttpError(403, "Eviction not allowed".into()));
+                }
+                self.handle_eviction_request(req).await
+            }
             _ => Err(HttpError(404, "Not found".into())),
         }
     }
 
-    /// Verify the incomming request does not exceed the maximum connection limit.
+    async fn handle_eviction_request(&self, req: &Request<IncomingBody>) -> Result<String, HttpError> {
+        let body_bytes = hyper::body::to_bytes(req.into_body()).await.map_err(|_| HttpError(400, "Invalid request body".into()))?;
+        let secret_id = String::from_utf8(body_bytes.to_vec()).map_err(|_| HttpError(400, "Invalid secret ID".into()))?;
+        
+        self.cache_mgr.evict_entry(&secret_id).await?;
+        Ok(format!("Successfully evicted secret: {}", secret_id))
+    }
+
+    /// Verify the incoming request does not exceed the maximum connection limit.
     ///
     /// The limit is not enforced for ping/health checks.
     ///
     /// # Arguments
     ///
-    /// * `req` - The incomming HTTP request.
+    /// * `req` - The incoming HTTP request.
     /// * `count` - The number of concurrent requets being handled.
     ///
     /// # Returns
@@ -209,7 +222,7 @@ impl Server {
     ///
     /// # Arguments
     ///
-    /// * `req` - The incomming HTTP request.
+    /// * `req` - The incoming HTTP request.
     ///
     /// # Returns
     ///
@@ -241,22 +254,21 @@ impl Server {
         Err(HttpError(403, "Bad Token".into()))
     }
 
-    /// Verify the request is using the GET HTTP verb.
+    /// Verify the request is using the GET or POST HTTP verb.
     ///
     /// # Arguments
     ///
-    /// * `req` - The incomming HTTP request.
+    /// * `req` - The incoming HTTP request.
     ///
     /// # Returns
     ///
-    /// * `Ok(())` - If the GET verb/method is use.
-    /// * `Err((u16, String))` - A 405 error codde and message when GET is not used.
+    /// * `Ok(())` - If the GET or POST verb/method is use.
+    /// * `Err((u16, String))` - A 405 error codde and message when GET or POST is not used.
     #[doc(hidden)]
     fn validate_method(&self, req: &Request<IncomingBody>) -> Result<(), HttpError> {
-        if *req.method() == Method::GET {
-            return Ok(());
+        match *req.method() {
+            Method::GET | Method::POST => Ok(()),
+            _ => Err(HttpError(405, "Method not allowed".into())),
         }
-
-        Err(HttpError(405, "Not allowed".into()))
     }
 }

--- a/aws_secretsmanager_caching/src/lib.rs
+++ b/aws_secretsmanager_caching/src/lib.rs
@@ -296,6 +296,17 @@ impl SecretsManagerCachingClient {
 
         Ok(false)
     }
+
+    /// Invalidates a secret in the cache, forcing a refresh on the next retrieval.
+    ///
+    /// # Arguments
+    ///
+    /// * `secret_id` - The ARN or name of the secret to invalidate.
+    pub async fn invalidate(&self, secret_id: &str) -> Result<(), Box<dyn Error>> {
+        let mut write_lock = self.store.write().await;
+        write_lock.invalidate(secret_id)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-secretsmanager-agent/issues/12

*Description of changes:*

This change adds support for manual cache eviction upon POST request with a secret id.

- Add a new config field `allow_eviction: bool` to control whether cache eviction is allowed.
- Modify the server to allow POST to the `/evict` path.
- Add a function to handle eviction requests.
- Update the cache manager to support removing a specific entry from the cache.
- Update relevant tests.